### PR TITLE
Feature/is equal validator

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,6 +5,7 @@ en:
       inequality: "cannot be equal to %{attr}"
       equality: "must be equal to %{attr}"
       is_equal: "must be equal to %{value}"
+      is_not_equal: "cannot be equal to %{value}"
       email: "is not a valid email address"
       url: "is not a valid URL"
       mac_address: "is not a valid MAC address"
@@ -20,8 +21,11 @@ en:
         failure_message_for_should: "#{model} should ensure equality on attribute #{attr}"
         failure_message_for_should_not: "#{model} should not ensure equality on attribute #{attr}"
       ensure_is_equal:
-        failure_message_for_should: "#{model} should ensure equality of attribute #{attr} with #{value}"
-        failure_message_for_should_not: "#{model} should not ensure equality of attribute #{attr} with #{value}"
+        failure_message_for_should: "#{model} should ensure attribute #{attr} is equal to #{value}"
+        failure_message_for_should_not: "#{model} should not ensure attribute #{attr} is equal to #{value}"
+      ensure_is_not_equal:
+        failure_message_for_should: "#{model} should ensure attribute #{attr} is not equal to #{value}"
+        failure_message_for_should_not: "#{model} should not ensure attribute #{attr} is equal to #{value}"
       ensure_valid_email_format_of:
         failure_message_for_should: "#{model} should ensure valid email format of attribute #{attr}"
         failure_message_for_should_not: "#{model} should not ensure valid email format of attribute #{attr}"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -4,6 +4,7 @@ en:
       imei: "is not a valid IMEI"
       inequality: "cannot be equal to %{attr}"
       equality: "must be equal to %{attr}"
+      is_equal: "must be equal to %{value}"
       email: "is not a valid email address"
       url: "is not a valid URL"
       mac_address: "is not a valid MAC address"
@@ -18,6 +19,9 @@ en:
       ensure_equality_of:
         failure_message_for_should: "#{model} should ensure equality on attribute #{attr}"
         failure_message_for_should_not: "#{model} should not ensure equality on attribute #{attr}"
+      ensure_is_equal:
+        failure_message_for_should: "#{model} should ensure equality of attribute #{attr} with #{value}"
+        failure_message_for_should_not: "#{model} should not ensure equality of attribute #{attr} with #{value}"
       ensure_valid_email_format_of:
         failure_message_for_should: "#{model} should ensure valid email format of attribute #{attr}"
         failure_message_for_should_not: "#{model} should not ensure valid email format of attribute #{attr}"

--- a/lib/missing_validators.rb
+++ b/lib/missing_validators.rb
@@ -21,3 +21,7 @@ require 'missing_validators/validators/latitude_validator'
 require 'missing_validators/validators/color_validator'
 require 'missing_validators/validators/imei_validator'
 require 'missing_validators/matchers/ensure_valid_imei_format_of' if defined?(RSpec)
+
+# if you put your locales in <GEM_ROOT>/config/locales, they will be picked up automatically...
+# But only if the gem is a Rails Engine, and this is not that.
+I18n.load_path << File.expand_path('../../config/locales/en.yml', __FILE__)

--- a/lib/missing_validators.rb
+++ b/lib/missing_validators.rb
@@ -6,6 +6,8 @@ require 'missing_validators/validators/inequality_validator'
 require 'missing_validators/matchers/ensure_inequality_of_matcher' if defined?(RSpec)
 require 'missing_validators/validators/equality_validator'
 require 'missing_validators/matchers/ensure_equality_of_matcher' if defined?(RSpec)
+require 'missing_validators/validators/is_equal_validator'
+require 'missing_validators/matchers/ensure_is_equal_matcher' if defined?(RSpec)
 require 'missing_validators/validators/email_validator'
 require 'missing_validators/matchers/ensure_valid_email_format_of' if defined?(RSpec)
 require 'missing_validators/validators/url_validator'

--- a/lib/missing_validators.rb
+++ b/lib/missing_validators.rb
@@ -8,6 +8,8 @@ require 'missing_validators/validators/equality_validator'
 require 'missing_validators/matchers/ensure_equality_of_matcher' if defined?(RSpec)
 require 'missing_validators/validators/is_equal_validator'
 require 'missing_validators/matchers/ensure_is_equal_matcher' if defined?(RSpec)
+require 'missing_validators/validators/is_not_equal_validator'
+require 'missing_validators/matchers/ensure_is_not_equal_matcher' if defined?(RSpec)
 require 'missing_validators/validators/email_validator'
 require 'missing_validators/matchers/ensure_valid_email_format_of' if defined?(RSpec)
 require 'missing_validators/validators/url_validator'

--- a/lib/missing_validators/matchers/ensure_is_equal_matcher.rb
+++ b/lib/missing_validators/matchers/ensure_is_equal_matcher.rb
@@ -1,0 +1,30 @@
+RSpec::Matchers.define :ensure_is_equal do |attribute|
+  chain :to do |to|
+    @to = to
+  end
+
+  match do |model|
+    model.send("#{attribute}=", @to)
+    model.valid?
+
+    # Should not have an error here
+    return false if model.errors.has_key?(attribute) && model.errors[attribute].include?(I18n.t('errors.messages.is_equal', value: @to))
+
+    model.send("#{attribute}=", !@to)
+    model.valid?
+
+    # Should have an error here
+    return true if model.errors.has_key?(attribute) && model.errors[attribute].include?(I18n.t('errors.messages.is_equal', value: @to))
+
+  end
+
+  failure_message do |model|
+    I18n.t 'missing_validators.matchers.ensure_is_equal.failure_message_for_should',
+      model: model.class, attr: attribute.inspect, value: @to
+  end
+
+  failure_message_when_negated do |model|
+    I18n.t 'missing_validators.matchers.ensure_is_equal.failure_message_for_should_not',
+      model: model.class, attr: attribute.inspect, value: @to
+  end
+end

--- a/lib/missing_validators/matchers/ensure_is_equal_matcher.rb
+++ b/lib/missing_validators/matchers/ensure_is_equal_matcher.rb
@@ -15,7 +15,6 @@ RSpec::Matchers.define :ensure_is_equal do |attribute|
 
     # Should have an error here
     return true if model.errors.has_key?(attribute) && model.errors[attribute].include?(I18n.t('errors.messages.is_equal', value: @to))
-
   end
 
   failure_message do |model|

--- a/lib/missing_validators/matchers/ensure_is_not_equal_matcher.rb
+++ b/lib/missing_validators/matchers/ensure_is_not_equal_matcher.rb
@@ -1,0 +1,29 @@
+RSpec::Matchers.define :ensure_is_not_equal do |attribute|
+  chain :to do |to|
+    @to = to
+  end
+
+  match do |model|
+    model.send("#{attribute}=", !@to)
+    model.valid?
+
+    # Should not have an error here
+    return false if model.errors.has_key?(attribute) && model.errors[attribute].include?(I18n.t('errors.messages.is_not_equal', value: !@to))
+
+    model.send("#{attribute}=", @to)
+    model.valid?
+
+    # Should have an error here
+    return true if model.errors.has_key?(attribute) && model.errors[attribute].include?(I18n.t('errors.messages.is_not_equal', value: @to))
+  end
+
+  failure_message do |model|
+    I18n.t 'missing_validators.matchers.ensure_is_not_equal.failure_message_for_should',
+      model: model.class, attr: attribute.inspect, value: @to
+  end
+
+  failure_message_when_negated do |model|
+    I18n.t 'missing_validators.matchers.ensure_is_not_equal.failure_message_for_should_not',
+      model: model.class, attr: attribute.inspect, value: @to
+  end
+end

--- a/lib/missing_validators/validators/equality_validator.rb
+++ b/lib/missing_validators/validators/equality_validator.rb
@@ -2,7 +2,7 @@
 # the value of another attribute of an object.
 #
 class EqualityValidator < ActiveModel::EachValidator
-  # Checks if an attribute value is unequal to another attrubute value.
+  # Checks if an attribute value is unequal to another attribute value.
   #
   # @param [Object] record object to validate
   # @param [String] attribute name of the object attribute to validate

--- a/lib/missing_validators/validators/is_equal_validator.rb
+++ b/lib/missing_validators/validators/is_equal_validator.rb
@@ -1,0 +1,17 @@
+# Allows to check if the value of a specific attribute is equal to
+# the value of another attribute of an object.
+#
+class IsEqualValidator < ActiveModel::EachValidator
+  # Checks if an attribute value is unequal to another attribute value.
+  #
+  # @param [Object] record object to validate
+  # @param [String] attribute name of the object attribute to validate
+  # @param [Object] value attribute value
+  def validate_each(record, attribute, value)
+    equal_to_value = options[:to]
+    if equal_to_value && value != equal_to_value
+      message = options[:message] || I18n.t('errors.messages.is_equal', value: equal_to_value)
+      record.errors[attribute] << message
+    end
+  end
+end

--- a/lib/missing_validators/validators/is_equal_validator.rb
+++ b/lib/missing_validators/validators/is_equal_validator.rb
@@ -1,12 +1,10 @@
-# Allows to check if the value of a specific attribute is equal to
-# the value of another attribute of an object.
+# Allows to check if the value of a specific attribute is equal to another value
 #
 class IsEqualValidator < ActiveModel::EachValidator
-  # Checks if an attribute value is unequal to another attribute value.
   #
   # @param [Object] record object to validate
   # @param [String] attribute name of the object attribute to validate
-  # @param [Object] value attribute value
+  # @param [Object] value checks against this value
   def validate_each(record, attribute, value)
     equal_to_value = options[:to]
     if equal_to_value && value != equal_to_value

--- a/lib/missing_validators/validators/is_not_equal_validator.rb
+++ b/lib/missing_validators/validators/is_not_equal_validator.rb
@@ -1,0 +1,15 @@
+# Allows to check if the value of a specific attribute is not equal to another value
+#
+class IsNotEqualValidator < ActiveModel::EachValidator
+  #
+  # @param [Object] record object to validate
+  # @param [String] attribute name of the object attribute to validate
+  # @param [Object] value checks against this value
+  def validate_each(record, attribute, value)
+    not_equal_to_value = options[:to]
+    if value == not_equal_to_value
+      message = options[:message] || I18n.t('errors.messages.is_not_equal', value: not_equal_to_value)
+      record.errors[attribute] << message
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,4 +6,3 @@ require 'shoulda/matchers/active_record'
 require 'shoulda-matchers'
 
 I18n.enforce_available_locales = false
-I18n.load_path << File.expand_path("../../config/locales/en.yml", __FILE__)

--- a/spec/validators/is_equal_validator_spec.rb
+++ b/spec/validators/is_equal_validator_spec.rb
@@ -1,0 +1,84 @@
+require 'spec_helper'
+
+describe IsEqualValidator do
+
+  describe do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :attr
+        validates :attr, is_equal: { to: 1234 }
+      end
+    end
+
+    subject(:model){ klass.new }
+
+    specify "field is not the same as the result of the validating proc" do
+      model.attr = "invalid value"
+      expect(model).to be_invalid
+    end
+
+    specify "field is the same as the result of the validating proc" do
+      model.attr = 1234
+      expect(model).to be_valid
+    end
+  end
+
+  describe do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :origin, :destination
+        validates :origin, is_equal: { to: 54321 }
+        validates :destination, is_equal: { to: '12345' }
+      end
+    end
+
+    subject(:model){ klass.new }
+
+    it { should ensure_is_equal(:origin).to(54321) }
+    it { should_not ensure_is_equal(:origin).to(12345) }
+    it { should_not ensure_is_equal(:origin).to(nil) }
+    it { should_not ensure_is_equal(:origin).to([]) }
+    it { should_not ensure_is_equal(:origin).to('54321') }
+
+    it { should ensure_is_equal(:destination).to('12345') }
+    it { should_not ensure_is_equal(:destination).to('54321') }
+    it { should_not ensure_is_equal(:destination).to(nil) }
+    it { should_not ensure_is_equal(:destination).to([]) }
+    it { should_not ensure_is_equal(:destination).to(12345) }
+
+    specify "valid value" do
+      model.origin = 54321
+      model.destination = '12345'
+      expect(model).to be_valid
+    end
+
+    specify "fields are nil" do
+      model.origin = nil
+      model.destination = nil
+      expect(model).to be_invalid
+    end
+
+    specify "incorrect values" do
+      model.origin = 12345
+      model.destination = 12345
+      expect(model).to be_invalid
+    end
+
+
+    specify "half right with nil" do
+      model.origin = 54321
+      model.destination = nil
+      expect(model).to be_invalid
+    end
+
+
+    specify "half right with other value" do
+      model.origin = 'asdfg'
+      model.destination = '12345'
+      expect(model).to be_invalid
+    end
+
+  end
+end

--- a/spec/validators/is_not_equal_validator_spec.rb
+++ b/spec/validators/is_not_equal_validator_spec.rb
@@ -1,0 +1,142 @@
+require 'spec_helper'
+
+describe IsNotEqualValidator do
+
+  describe do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :attr
+        validates :attr, is_not_equal: { to: 1234 }
+      end
+    end
+
+    subject(:model){ klass.new }
+
+    specify "field is not the same as the result of the validating proc" do
+      model.attr = "invalid value"
+      expect(model).to be_valid
+    end
+
+    specify "field is the same as the result of the validating proc" do
+      model.attr = 1234
+      expect(model).to be_invalid
+    end
+  end
+
+  describe do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :origin, :destination
+        validates :origin, is_not_equal: { to: 54321 }
+        validates :destination, is_not_equal: { to: '12345' }
+      end
+    end
+
+    subject(:model){ klass.new }
+
+    it { should ensure_is_not_equal(:origin).to(54321) }
+    it { should_not ensure_is_not_equal(:origin).to(12345) }
+    it { should_not ensure_is_not_equal(:origin).to(nil) }
+    it { should_not ensure_is_not_equal(:origin).to([]) }
+    it { should_not ensure_is_not_equal(:origin).to('54321') }
+
+    it { should ensure_is_not_equal(:destination).to('12345') }
+    it { should_not ensure_is_not_equal(:destination).to('54321') }
+    it { should_not ensure_is_not_equal(:destination).to(nil) }
+    it { should_not ensure_is_not_equal(:destination).to([]) }
+    it { should_not ensure_is_not_equal(:destination).to(12345) }
+
+    specify "invalid value" do
+      model.origin = 54321
+      model.destination = '12345'
+      expect(model).to be_invalid
+    end
+
+    specify "fields are nil" do
+      model.origin = nil
+      model.destination = nil
+      expect(model).to be_valid
+    end
+
+    specify "incorrect values" do
+      model.origin = 12345
+      model.destination = 12345
+      expect(model).to be_valid
+    end
+
+
+    specify "half match with nil" do
+      model.origin = 54321
+      model.destination = nil
+      expect(model).to be_invalid
+    end
+
+
+    specify "half match with other value" do
+      model.origin = 'asdfg'
+      model.destination = '12345'
+      expect(model).to be_invalid
+    end
+
+  end
+
+  describe do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :origin, :destination
+        validates :origin, is_not_equal: { to: true }
+        validates :destination, is_not_equal: { to: false }
+      end
+    end
+
+    subject(:model){ klass.new }
+
+    it { should ensure_is_not_equal(:origin).to(true) }
+    it { should_not ensure_is_not_equal(:origin).to(false) }
+    it { should_not ensure_is_not_equal(:origin).to(nil) }
+    it { should_not ensure_is_not_equal(:origin).to([]) }
+    it { should_not ensure_is_not_equal(:origin).to('54321') }
+
+    it { should ensure_is_not_equal(:destination).to(false) }
+    it { should_not ensure_is_not_equal(:destination).to(true) }
+    it { should_not ensure_is_not_equal(:destination).to(nil) }
+    it { should_not ensure_is_not_equal(:destination).to([]) }
+    it { should_not ensure_is_not_equal(:destination).to(12345) }
+
+    specify "invalid value" do
+      model.origin = true
+      model.destination = false
+      expect(model).to be_invalid
+    end
+
+    specify "fields are nil" do
+      model.origin = nil
+      model.destination = nil
+      expect(model).to be_valid
+    end
+
+    specify "incorrect values" do
+      model.origin = 12345
+      model.destination = 12345
+      expect(model).to be_valid
+    end
+
+
+    specify "half match with nil" do
+      model.origin = true
+      model.destination = nil
+      expect(model).to be_invalid
+    end
+
+
+    specify "half match with other value" do
+      model.origin = 'asdfg'
+      model.destination = false
+      expect(model).to be_invalid
+    end
+
+  end
+end


### PR DESCRIPTION
```
validates :thing, is_equal: { to: 12345 }
validates :thing, is_not_equal: { to: 12345 }
```

is better (faster) than using a Proc with the existing equality validator:

```
validates :thing, equality: { to: Proc.new { 12345 }  }
validates :thing, inequality: { to: Proc.new { 12345 }  }
```