### PR TITLE
Add missing specs for coordinate matchers

### DIFF
--- a/spec/validators/latitude_validator_spec.rb
+++ b/spec/validators/latitude_validator_spec.rb
@@ -4,7 +4,7 @@ describe LatitudeValidator do
   let(:klass) do
     Class.new do
       include ActiveModel::Validations
-      attr_accessor :lat
+      attr_accessor :lat, :name
       validates :lat, latitude: true
     end
   end
@@ -21,4 +21,7 @@ describe LatitudeValidator do
 
   it { is_expected.not_to allow_value(nil).for(:lat) }
   it { is_expected.not_to allow_value('').for(:lat) }
+
+  it { is_expected.to ensure_valid_latitude_format_of(:lat) }
+  it { is_expected.to_not ensure_valid_latitude_format_of(:name) }
 end

--- a/spec/validators/longitude_validator_spec.rb
+++ b/spec/validators/longitude_validator_spec.rb
@@ -4,7 +4,7 @@ describe LongitudeValidator do
   let(:klass) do
     Class.new do
       include ActiveModel::Validations
-      attr_accessor :lon
+      attr_accessor :lon, :name
       validates :lon, longitude: true
     end
   end
@@ -21,4 +21,7 @@ describe LongitudeValidator do
 
   it { is_expected.not_to allow_value(nil).for(:lon) }
   it { is_expected.not_to allow_value('').for(:lon) }
+
+  it { is_expected.to ensure_valid_longitude_format_of(:lon) }
+  it { is_expected.to_not ensure_valid_longitude_format_of(:name) }
 end


### PR DESCRIPTION
Sorry I missed this. I didn't see specs for your matchers, but realized I dropped coverage.  This will make sure the matchers perform as expected similar to the tests your other matchers have!