### PR TITLE
Add missing matchers for ip_address

### DIFF
--- a/lib/missing_validators.rb
+++ b/lib/missing_validators.rb
@@ -24,6 +24,7 @@ if defined?(RSpec)
   require 'missing_validators/matchers/ensure_valid_imei_format_of'
   require 'missing_validators/matchers/ensure_valid_latitude_format_of'
   require 'missing_validators/matchers/ensure_valid_longitude_format_of'
+  require 'missing_validators/matchers/ensure_valid_ip_address_format_of'
 end
 
 I18n.load_path << File.expand_path('../locales/en.yml', __FILE__)

--- a/spec/validators/ip_address_validator_spec.rb
+++ b/spec/validators/ip_address_validator_spec.rb
@@ -1,0 +1,23 @@
+require 'spec_helper'
+
+describe IpAddressValidator do
+  subject { klass.new }
+
+  context 'ip_address must be in the valid format' do
+    let(:klass) do
+      Class.new do
+        include ActiveModel::Validations
+        attr_accessor :ip, :name
+        validates :ip, ip_address: true
+      end
+    end
+
+    it { is_expected.to allow_value('192.168.10.0').for(:ip) }
+    it { is_expected.to allow_value('127.0.0.1').for(:ip) }
+    it { is_expected.not_to allow_value('129.512.12.0').for(:ip) }
+
+    it { is_expected.to ensure_valid_ip_address_format_of(:ip) }
+    it { is_expected.not_to ensure_valid_ip_address_format_of(:name) }
+  end
+
+end


### PR DESCRIPTION
Hi Andrewgr 

I was getting below error message and so i tried to fix it. 
  ```
  Failures:

  1) Server validations 
     Failure/Error: it { should ensure_valid_ip_address_format_of(:ip)  }
     
     NameError:
       undefined local variable or method `ensure_valid_ip_address_format_of' for #<RSpec::ExampleGroups::Server::Validations:0x007fa783892650>
       Did you mean?  ensure_valid_mac_address_format_of
                      ensure_valid_latitude_format_of
                      ensure_valid_email_format_of
                      ensure_valid_imei_format_of
                      ensure_valid_url_format_of

```
Could you please review it. 
Regards,
Hare